### PR TITLE
SL-18943 Enable manual trigger for the GHA builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build
-on: [push]
+on: 
+  push:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
We need to rebuild the package regularly to pick up the updated certs. Manual trigger should be enough for this.